### PR TITLE
Update version to 15.1.0 for project and parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>fess-ds-db</artifactId>
 	<packaging>jar</packaging>
 	<name>Database Data Store</name>
-	<version>15.0.1-SNAPSHOT</version>
+	<version>15.1.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-ds-db.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-ds-db.git</developerConnection>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.0.0</version>
+		<version>15.1.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
This change updates the Maven project version from 15.0.1-SNAPSHOT to 15.1.0-SNAPSHOT, and also updates the parent POM version from 15.0.0 to 15.1.0. These changes align the module with the next planned release and ensure compatibility with the updated parent settings.
